### PR TITLE
fix(RichPresence): check activity assets' existence

### DIFF
--- a/src/components/molecules/RichPresence.svelte
+++ b/src/components/molecules/RichPresence.svelte
@@ -118,7 +118,7 @@
 							? `https://cdn.discordapp.com/app-assets/${data.activities[activityNumber].application_id}/${data.activities[activityNumber].assets.large_image}.webp?size=512`
 							: images[activity] || 'question_mark.png';
 						smallImage = '';
-						if (data.activities[activityNumber].assets.small_image) {
+						if (data.activities[activityNumber].assets && data.activities[activityNumber].assets.small_image) {
 							smallImage = `https://cdn.discordapp.com/app-assets/${data.activities[activityNumber].application_id}/${data.activities[activityNumber].assets.small_image}.webp?size=512`;
 						}
 						cancelAnimationFrame(currentRequestAnimationFrame);


### PR DESCRIPTION
when defining `smallImage`, you assume that `data.activities[activityNumber].assets` exists, if it doesn't, an error occurs which leads to the details of the Rich Presence module to not exist cause of the error. 

![Clip Studio Paint](https://i.gyazo.com/67efe14077085255a78337ac671fcbd5.png)